### PR TITLE
GEOPY-1527: Make the canny add_data optional on get_edges method 

### DIFF
--- a/simpeg_drivers/joint/params.py
+++ b/simpeg_drivers/joint/params.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from geoh5py.groups.simpeg_group import SimPEGGroup
+from geoh5py.groups import SimPEGGroup
 
 from simpeg_drivers.params import InversionBaseParams
 


### PR DESCRIPTION
**GEOPY-1527 - Make the canny add_data optional on get_edges method **
