### PR TITLE
GEOPY-1584: import of simpeg-drivers too slow

### DIFF
--- a/simpeg_drivers/__init__.py
+++ b/simpeg_drivers/__init__.py
@@ -21,8 +21,6 @@ __version__ = "0.1.0-rc.2"
 
 from pathlib import Path
 
-from SimPEG import dask
-
 from simpeg_drivers.constants import default_ui_json
 from simpeg_drivers.params import InversionBaseParams
 
@@ -30,7 +28,6 @@ __all__ = [
     "DRIVER_MAP",
     "InversionBaseParams",
     "assets_path",
-    "dask",
     "default_ui_json",
 ]
 

--- a/simpeg_drivers/driver.py
+++ b/simpeg_drivers/driver.py
@@ -14,7 +14,7 @@
 #  not be provided or otherwise made available to any other person.
 #
 # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
+# flake8: noqa
 
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ from geoh5py.shared.utils import fetch_active_workspace
 from geoh5py.ui_json import InputFile
 from param_sweeps.driver import SweepParams
 from SimPEG import (
+    dask,
     directives,
     inverse_problem,
     inversion,


### PR DESCRIPTION
**GEOPY-1584 - import of simpeg-drivers too slow**
