### PR TITLE
GEOPY-1698: relock conda env on new geoapps-utils

### DIFF
--- a/environments/py-3.10-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.10-linux-64-dev.conda.lock.yml
@@ -44,7 +44,7 @@ dependencies:
   - cytoolz=0.12.3=py310h2372a71_0
   - dask-core=2024.6.2=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
-  - debugpy=1.8.2=py310h76e45a6_0
+  - debugpy=1.8.3=py310hea249c9_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - dill=0.3.8=pyhd8ed1ab_0
@@ -293,9 +293,9 @@ dependencies:
   - pip:
       - empymod === 2.3.1
       - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
       - numba === 0.60.0
       - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
       - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd

--- a/environments/py-3.10-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.10-linux-64-dev.conda.lock.yml
@@ -116,7 +116,7 @@ dependencies:
   - libbrotlidec=1.1.0=hd590300_1
   - libbrotlienc=1.1.0=hd590300_1
   - libcblas=3.9.0=20_linux64_mkl
-  - libcurl=8.9.0=hdb1bdb2_0
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libdlf=0.2.0=pyhd8ed1ab_0
   - libedit=3.1.20191231=he28a2e2_2
@@ -182,7 +182,7 @@ dependencies:
   - pexpect=4.9.0=pyhd8ed1ab_0
   - pickleshare=0.7.5=py_1003
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
@@ -226,7 +226,7 @@ dependencies:
   - scikit-learn=1.4.2=py310h981052a_1
   - scipy=1.14.0=py310h93e2701_1
   - send2trash=1.8.3=pyh0d859eb_0
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - six=1.16.0=pyh6c4a22f_0
   - sniffio=1.3.1=pyhd8ed1ab_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -292,13 +292,13 @@ dependencies:
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
       - empymod === 2.3.1
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
       - numba === 0.60.0
-      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
-      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
+      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
       - scooby === 0.10.0
 
 variables:

--- a/environments/py-3.10-linux-64.conda.lock.yml
+++ b/environments/py-3.10-linux-64.conda.lock.yml
@@ -56,7 +56,7 @@ dependencies:
   - libbrotlidec=1.1.0=hd590300_1
   - libbrotlienc=1.1.0=hd590300_1
   - libcblas=3.9.0=20_linux64_mkl
-  - libcurl=8.9.0=hdb1bdb2_0
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libdlf=0.2.0=pyhd8ed1ab_0
   - libedit=3.1.20191231=he28a2e2_2
@@ -98,7 +98,7 @@ dependencies:
   - pandas=2.2.2=py310hf9f9076_1
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - psutil=6.0.0=py310hc51659f_0
   - pthread-stubs=0.4=h36c2ea0_1001
   - pycparser=2.22=pyhd8ed1ab_0
@@ -118,7 +118,7 @@ dependencies:
   - readline=8.2=h8228510_1
   - scikit-learn=1.4.2=py310h981052a_1
   - scipy=1.14.0=py310h93e2701_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - six=1.16.0=pyh6c4a22f_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - tbb=2021.12.0=h434a139_3
@@ -145,13 +145,13 @@ dependencies:
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
       - empymod === 2.3.1
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
       - numba === 0.60.0
-      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
-      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
+      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
       - scooby === 0.10.0
 
 variables:

--- a/environments/py-3.10-linux-64.conda.lock.yml
+++ b/environments/py-3.10-linux-64.conda.lock.yml
@@ -146,9 +146,9 @@ dependencies:
   - pip:
       - empymod === 2.3.1
       - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
       - numba === 0.60.0
       - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
       - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd

--- a/environments/py-3.10-win-64-dev.conda.lock.yml
+++ b/environments/py-3.10-win-64-dev.conda.lock.yml
@@ -41,7 +41,7 @@ dependencies:
   - cytoolz=0.12.3=py310h8d17308_0
   - dask-core=2024.6.2=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
-  - debugpy=1.8.2=py310h9e98ed7_0
+  - debugpy=1.8.3=py310h9e98ed7_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - dill=0.3.8=pyhd8ed1ab_0
@@ -288,9 +288,9 @@ dependencies:
   - pip:
       - empymod === 2.3.1
       - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
       - numba === 0.60.0
       - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
       - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd

--- a/environments/py-3.10-win-64-dev.conda.lock.yml
+++ b/environments/py-3.10-win-64-dev.conda.lock.yml
@@ -111,7 +111,7 @@ dependencies:
   - libbrotlidec=1.1.0=hcfcfb64_1
   - libbrotlienc=1.1.0=hcfcfb64_1
   - libcblas=3.9.0=20_win64_mkl
-  - libcurl=8.9.0=h18fefc2_0
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libdlf=0.2.0=pyhd8ed1ab_0
   - libffi=3.4.2=h8ffe710_5
@@ -170,7 +170,7 @@ dependencies:
   - partd=1.4.2=pyhd8ed1ab_0
   - pickleshare=0.7.5=py_1003
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
@@ -215,7 +215,7 @@ dependencies:
   - scikit-learn=1.4.2=py310hf2a6c47_1
   - scipy=1.14.0=py310h46043a1_1
   - send2trash=1.8.3=pyh5737063_0
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - six=1.16.0=pyh6c4a22f_0
   - sniffio=1.3.1=pyhd8ed1ab_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -287,13 +287,13 @@ dependencies:
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
       - empymod === 2.3.1
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
       - numba === 0.60.0
-      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
-      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
+      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
       - scooby === 0.10.0
 
 variables:

--- a/environments/py-3.10-win-64.conda.lock.yml
+++ b/environments/py-3.10-win-64.conda.lock.yml
@@ -140,9 +140,9 @@ dependencies:
   - pip:
       - empymod === 2.3.1
       - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
       - numba === 0.60.0
       - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
       - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd

--- a/environments/py-3.10-win-64.conda.lock.yml
+++ b/environments/py-3.10-win-64.conda.lock.yml
@@ -51,7 +51,7 @@ dependencies:
   - libbrotlidec=1.1.0=hcfcfb64_1
   - libbrotlienc=1.1.0=hcfcfb64_1
   - libcblas=3.9.0=20_win64_mkl
-  - libcurl=8.9.0=h18fefc2_0
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libdlf=0.2.0=pyhd8ed1ab_0
   - libffi=3.4.2=h8ffe710_5
@@ -87,7 +87,7 @@ dependencies:
   - pandas=2.2.2=py310hb4db72f_1
   - partd=1.4.2=pyhd8ed1ab_0
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - psutil=6.0.0=py310ha8f682b_0
   - pthread-stubs=0.4=hcd874cb_1001
   - pthreads-win32=2.9.1=hfa6e2cd_3
@@ -107,7 +107,7 @@ dependencies:
   - pyyaml=6.0.1=py310h8d17308_1
   - scikit-learn=1.4.2=py310hf2a6c47_1
   - scipy=1.14.0=py310h46043a1_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - six=1.16.0=pyh6c4a22f_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - tbb=2021.12.0=hc790b64_3
@@ -139,13 +139,13 @@ dependencies:
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
       - empymod === 2.3.1
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
       - llvmlite === 0.43.0
-      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+      - mira-simpeg @ git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
       - numba === 0.60.0
-      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
-      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+      - octree-creation-app @ git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
+      - param-sweeps @ git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
       - scooby === 0.10.0
 
 variables:

--- a/py-3.10.conda-lock.yml
+++ b/py-3.10.conda-lock.yml
@@ -1035,22 +1035,23 @@ package:
   category: dev
   optional: true
 - name: debugpy
-  version: 1.8.2
+  version: 1.8.3
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py310h76e45a6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.3-py310hea249c9_0.conda
   hash:
-    md5: 285568244bd06fbe2cccf2ee1617f582
-    sha256: 774223fe937ab70312502a0dede4a567d16f41ab034444965ba03e5e1b4928fa
+    md5: 83f5c0c233fa7b1fa6c97bfc6c6bcb2d
+    sha256: 310d2ab3922859a811eb305eb41deaac0a3340d98c5ac68db37046e455e2a5f2
   category: dev
   optional: true
 - name: debugpy
-  version: 1.8.2
+  version: 1.8.3
   manager: conda
   platform: win-64
   dependencies:
@@ -1059,10 +1060,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.2-py310h9e98ed7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.3-py310h9e98ed7_0.conda
   hash:
-    md5: 6edfa966360b5df86d7277b0a4829381
-    sha256: d9d3b4d1dd3b00a8fd2caae02285902a294aad8d633620f517ffcf89d38fb57a
+    md5: 621c228b485320dfc7c9f587aa7f0157
+    sha256: 0583870d5de14fa43db5f7aa079a31ee7557bd745c6b59b08f8453db5932baff
   category: dev
   optional: true
 - name: decorator
@@ -8199,13 +8200,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
   hash:
-    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+    sha256: f95bdfb2ab74f30b0d0d67abc398370c261d1823
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -8216,13 +8217,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
   hash:
-    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+    sha256: f95bdfb2ab74f30b0d0d67abc398370c261d1823
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@f95bdfb2ab74f30b0d0d67abc398370c261d1823
   optional: false
 - name: llvmlite
   version: 0.43.0
@@ -8245,7 +8246,7 @@ package:
   category: main
   optional: false
 - name: mira-simpeg
-  version: 0.21.2.1a1
+  version: 0.21.2.1.dev2+g5cf52f6d8
   manager: pip
   platform: linux-64
   dependencies:
@@ -8259,16 +8260,16 @@ package:
     pymatsolver: '>=0.2'
     scikit-learn: '>=1.2'
     scipy: '>=1.8.0'
-  url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+  url: git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   hash:
-    sha256: 2492d3b603c32dd8dce5b440af048c907d8bb20c
+    sha256: 5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+    url: git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   optional: false
 - name: mira-simpeg
-  version: 0.21.2.1a1
+  version: 0.21.2.1.dev2+g5cf52f6d8
   manager: pip
   platform: win-64
   dependencies:
@@ -8282,13 +8283,13 @@ package:
     pymatsolver: '>=0.2'
     scikit-learn: '>=1.2'
     scipy: '>=1.8.0'
-  url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+  url: git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   hash:
-    sha256: 2492d3b603c32dd8dce5b440af048c907d8bb20c
+    sha256: 5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
+    url: git+https://github.com/MiraGeoscience/simpeg@5cf52f6d8d0cd9ccb36ffc26eb3196e9fc37b4d9
   optional: false
 - name: numba
   version: 0.60.0

--- a/py-3.10.conda-lock.yml
+++ b/py-3.10.conda-lock.yml
@@ -2482,8 +2482,8 @@ package:
     click: ''
     importlib-metadata: ''
     tabulate: ''
-    nbformat: ''
     attrs: ''
+    nbformat: ''
     python: '>=3.8'
     sqlalchemy: '>=1.3.12,<3'
     nbclient: '>=0.2,<0.8'
@@ -3219,7 +3219,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.9.0
+  version: 8.9.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -3230,14 +3230,14 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.0-hdb1bdb2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.1-hdb1bdb2_0.conda
   hash:
-    md5: 5badfbdb2688d8aaca7bd3c98d557b97
-    sha256: ff97a3160117385649e1b7e8b84fefb3561fceae09bb48d2bfdf37bc2b6bfdc9
+    md5: 7da1d242ca3591e174a3c7d82230d3c0
+    sha256: 0ba60f83709068e9ec1ab543af998cb5a201c8379c871205447684a34b5abfd8
   category: main
   optional: false
 - name: libcurl
-  version: 8.9.0
+  version: 8.9.1
   manager: conda
   platform: win-64
   dependencies:
@@ -3247,10 +3247,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.0-h18fefc2_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.1-h18fefc2_0.conda
   hash:
-    md5: 8ae225681b7041c1dccdcd713c9d7424
-    sha256: ccf4c2088bb89c88841eb87264050a8c26767222e0b97afb2dbc41a46e0017e0
+    md5: 099a1016d23baa4f41148a985351a7a8
+    sha256: 024be133aed5f100c0b222761e747cc27a2bdf94af51947ad5f70e88cf824988
   category: main
   optional: false
 - name: libdeflate
@@ -5046,31 +5046,31 @@ package:
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: win-64
   dependencies:
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: pkgutil-resolve-name
@@ -6347,27 +6347,27 @@ package:
   category: dev
   optional: true
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: six
@@ -8161,38 +8161,34 @@ package:
   manager: pip
   platform: linux-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoapps-utils
   version: 0.4.0a1
   manager: pip
   platform: win-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -8203,13 +8199,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: b5064fb631056dcaa57e379719e923fcd1195f6b
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -8220,13 +8216,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: b5064fb631056dcaa57e379719e923fcd1195f6b
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@b5064fb631056dcaa57e379719e923fcd1195f6b
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false
 - name: llvmlite
   version: 0.43.0
@@ -8263,13 +8259,13 @@ package:
     pymatsolver: '>=0.2'
     scikit-learn: '>=1.2'
     scipy: '>=1.8.0'
-  url: git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+  url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
   hash:
-    sha256: b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+    sha256: 2492d3b603c32dd8dce5b440af048c907d8bb20c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+    url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
   optional: false
 - name: mira-simpeg
   version: 0.21.2.1a1
@@ -8286,13 +8282,13 @@ package:
     pymatsolver: '>=0.2'
     scikit-learn: '>=1.2'
     scipy: '>=1.8.0'
-  url: git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+  url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
   hash:
-    sha256: b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+    sha256: 2492d3b603c32dd8dce5b440af048c907d8bb20c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/simpeg@b643f1cb9a9fee76b5e4bd7ed4f1b7a65d1646ec
+    url: git+https://github.com/MiraGeoscience/simpeg@2492d3b603c32dd8dce5b440af048c907d8bb20c
   optional: false
 - name: numba
   version: 0.60.0
@@ -8331,13 +8327,13 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+  url: git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
   hash:
-    sha256: 7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+    sha256: a88c1e341d173bd26f4f321c47433c6964aa24f4
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+    url: git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
   optional: false
 - name: octree-creation-app
   version: 0.2.0a1
@@ -8352,13 +8348,13 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+  url: git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
   hash:
-    sha256: 7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+    sha256: a88c1e341d173bd26f4f321c47433c6964aa24f4
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/octree-creation-app@7248a2568f3a3fd9b69b14da0b7257c7eeec2ac8
+    url: git+https://github.com/MiraGeoscience/octree-creation-app@a88c1e341d173bd26f4f321c47433c6964aa24f4
   optional: false
 - name: param-sweeps
   version: 0.2.0a1
@@ -8367,13 +8363,13 @@ package:
   dependencies:
     geoh5py: '>=0.9.1,<0.11'
     numpy: '>=1.26.0,<1.27.0'
-  url: git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+  url: git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
   hash:
-    sha256: 1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+    sha256: 8263b65c79cbc80058bd153f3e8231e73992dccd
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+    url: git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
   optional: false
 - name: param-sweeps
   version: 0.2.0a1
@@ -8382,13 +8378,13 @@ package:
   dependencies:
     geoh5py: '>=0.9.1,<0.11'
     numpy: '>=1.26.0,<1.27.0'
-  url: git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+  url: git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
   hash:
-    sha256: 1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+    sha256: 8263b65c79cbc80058bd153f3e8231e73992dccd
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/param-sweeps@1bf3fdeee1ad44d0fd38c97e99081a3541f8bcac
+    url: git+https://github.com/MiraGeoscience/param-sweeps@8263b65c79cbc80058bd153f3e8231e73992dccd
   optional: false
 - name: scooby
   version: 0.10.0


### PR DESCRIPTION
**GEOPY-1698 - relock conda env of repos to use fixed revision of geoapps-utils**
