### PR TITLE
DEVOPS-483: Use timeout_minutes input in pytest-windows reusable workflow

### DIFF
--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -28,14 +28,14 @@ env:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-483
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
     with:
       package_manager: 'conda'
       app_name: ${{ github.env.app_name }}
       python_vers: '3.10'
   call-workflow-pytest-on-windows:
     name: Pytest on Windows
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-483
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@main
     with:
       package_manager: 'conda'
       python_ver: '["3.10"]'
@@ -46,7 +46,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   call-workflow-pytest-on-unix-os:
     name: Pytest on Unix OS
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-483
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@main
     with:
       package_manager: 'conda'
       python_ver: '["3.10"]'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -28,14 +28,14 @@ env:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-483
     with:
       package_manager: 'conda'
       app_name: ${{ github.env.app_name }}
       python_vers: '3.10'
   call-workflow-pytest-on-windows:
     name: Pytest on Windows
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-483
     with:
       package_manager: 'conda'
       python_ver: '["3.10"]'
@@ -46,7 +46,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   call-workflow-pytest-on-unix-os:
     name: Pytest on Unix OS
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-483
     with:
       package_manager: 'conda'
       python_ver: '["3.10"]'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -41,6 +41,7 @@ jobs:
       python_ver: '["3.10"]'
       cache_number: 1
       codecov_reference_python_ver: '3.10'
+      timeout_minutes: 40
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   call-workflow-pytest-on-unix-os:


### PR DESCRIPTION
**DEVOPS-483 - Add an optionnal timeout in reusable github workflow**

⚠️ Don't merge until this [PR](https://github.com/MiraGeoscience/CI-tools/pull/20) is merged and github workflows reference are updated