### PR TITLE
GEOPY-1727: Fix formatting of warning for LargeLoop reformating. Use logging instead warning 

### DIFF
--- a/simpeg_drivers/__init__.py
+++ b/simpeg_drivers/__init__.py
@@ -20,11 +20,15 @@ from __future__ import annotations
 
 __version__ = "0.2.0-alpha.1"
 
+
+import logging
 from pathlib import Path
 
 from simpeg_drivers.constants import default_ui_json
 from simpeg_drivers.params import InversionBaseParams
 
+
+logging.basicConfig(level=logging.INFO)
 
 __all__ = [
     "DRIVER_MAP",

--- a/simpeg_drivers/components/factories/entity_factory.py
+++ b/simpeg_drivers/components/factories/entity_factory.py
@@ -20,12 +20,8 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING
-from warnings import warn
-
-
-if TYPE_CHECKING:
-    from simpeg_drivers.components.data import InversionData
 
 import numpy as np
 from geoh5py.objects import (
@@ -40,6 +36,12 @@ from geoh5py.objects import (
 
 from simpeg_drivers.components.factories.abstract_factory import AbstractFactory
 from simpeg_drivers.utils.surveys import counter_clockwise_sort
+
+
+logger = getLogger(__name__)
+
+if TYPE_CHECKING:
+    from simpeg_drivers.components.data import InversionData
 
 
 class EntityFactory(AbstractFactory):
@@ -173,17 +175,17 @@ class EntityFactory(AbstractFactory):
             ccw_loops = counter_clockwise_sort(loop_cells, transmitter.vertices)
 
             if not np.all(ccw_loops == loop_cells):
-                messages.append("Counter-clockwise sorted, ")
+                messages.append("'counter-clockwise sorting'")
 
             # Check for closed loop
             if ccw_loops[-1, 1] != ccw_loops[0, 0]:
-                messages.append("Closed loop")
+                messages.append("'closed loop'")
                 ccw_loops = np.vstack(
                     [ccw_loops, np.c_[ccw_loops[-1, 1], ccw_loops[0, 0]]]
                 )
 
             if len(messages) > 0:
-                warn(f"Loop {tx_id} modified for: {', '.join(messages)}")
+                logger.info("Loop %i modified for: %s", tx_id, ", ".join(messages))
 
             all_loops.append(ccw_loops)
 

--- a/tests/run_tests/driver_ground_tem_test.py
+++ b/tests/run_tests/driver_ground_tem_test.py
@@ -17,11 +17,11 @@
 
 from __future__ import annotations
 
+from logging import INFO, getLogger
 from pathlib import Path
 
 import numpy as np
 from geoh5py.workspace import Workspace
-from pytest import warns
 
 from simpeg_drivers.electromagnetics.time_domain import TimeDomainElectromagneticsParams
 from simpeg_drivers.electromagnetics.time_domain.driver import (
@@ -29,6 +29,9 @@ from simpeg_drivers.electromagnetics.time_domain.driver import (
 )
 from simpeg_drivers.utils.testing import check_target, setup_inversion_workspace
 from simpeg_drivers.utils.utils import get_inversion_output
+
+
+logger = getLogger(__name__)
 
 
 # To test the full run and validate the inversion.
@@ -43,8 +46,10 @@ target_run = {
 
 def test_tiling_ground_tem(
     tmp_path: Path,
+    *,
     n_grid_points=4,
     refinement=(2,),
+    **_,
 ):
     # Run the forward
     geoh5, _, model, survey, topography = setup_inversion_workspace(
@@ -88,9 +93,13 @@ def test_tiling_ground_tem(
 
 def test_ground_tem_fwr_run(
     tmp_path: Path,
+    caplog,
     n_grid_points=4,
     refinement=(2,),
+    pytest=True,
 ):
+    if pytest:
+        caplog.set_level(INFO)
     # Run the forward
     geoh5, _, model, survey, topography = setup_inversion_workspace(
         tmp_path,
@@ -121,9 +130,15 @@ def test_ground_tem_fwr_run(
     fwr_driver = TimeDomainElectromagneticsDriver(params)
 
     survey.transmitters.remove_cells([15])
+    assert fwr_driver.inversion_data.survey.source_list[0].n_segments == 16
 
-    with warns(UserWarning, match="modified for"):
-        assert fwr_driver.inversion_data.survey.source_list[0].n_segments == 16
+    if pytest:
+        assert len(caplog.records) == 2
+        for record in caplog.records:
+            assert record.levelname == "INFO"
+            assert "counter-clockwise" in record.message
+
+        assert "closed" in caplog.records[0].message
 
     fwr_driver.run()
 
@@ -227,7 +242,9 @@ def test_ground_tem_run(tmp_path: Path, max_iterations=1, pytest=True):
 
 if __name__ == "__main__":
     # Full run
-    test_ground_tem_fwr_run(Path("./"), n_grid_points=5, refinement=(2, 2, 2))
+    test_ground_tem_fwr_run(
+        Path("./"), None, n_grid_points=5, refinement=(2, 2, 2), pytest=False
+    )
     test_ground_tem_run(
         Path("./"),
         max_iterations=15,


### PR DESCRIPTION
**GEOPY-1727 - Fix formatting of warning for LargeLoop reformating. Use logging instead warning **
