### PR TITLE
DEVOPS-544: Add a constrain on glibc inside the conda recipe

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -47,6 +47,7 @@ requirements:
   run_constrained:
     - tbb 2021.12.*
     - python-tzdata 2023.4.*
+    - glibc 2.17.*
 
 about:
   license: MIT


### PR DESCRIPTION
**DEVOPS-544 - constrain glibc on packages using simpeg**
