### PR TITLE
DEVOPS-544: more flexible constrained on glibc virtual package

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -47,7 +47,7 @@ requirements:
   run_constrained:
     - tbb 2021.12.*
     - python-tzdata 2023.4.*
-    - __glibc 2.17.*
+    - __glibc >=2.17
 
 about:
   license: MIT


### PR DESCRIPTION
**DEVOPS-544 - constrain glibc on packages using simpeg**
