### PR TITLE
GEOPY-1880: Auto-meshing: Only use depth_code (no vertical pads) for potential fields and DC-IP inversions

### DIFF
--- a/simpeg_drivers/components/meshes.py
+++ b/simpeg_drivers/components/meshes.py
@@ -125,7 +125,9 @@ class InversionMesh:
         """Automate meshing based on data and topography objects."""
 
         params = auto_mesh_parameters(
-            self.params.data_object, self.params.topography_object
+            self.params.data_object,
+            self.params.topography_object,
+            inversion_type=self.params.inversion_type,
         )
         self._mesh = OctreeDriver.treemesh_from_params(params)
 

--- a/simpeg_drivers/utils/meshes.py
+++ b/simpeg_drivers/utils/meshes.py
@@ -49,10 +49,8 @@ def auto_pad(survey, factor=2) -> tuple[list[float], list[float]]:
 
 def use_vertical_padding(inversion_type):
     """Return true for all electrical and potential field methods."""
-    out = False
-    if any(k in inversion_type for k in ["direct current", "induced polarization"]):
-        out = True
-    if inversion_type in ["gravity", "magnetic scalar", "magnetic vector"]:
+    out = True
+    if any(k in inversion_type for k in ["direct current", "induced polarization", "gravity", "magnetic"]):
         out = False
     return out
 

--- a/simpeg_drivers/utils/meshes.py
+++ b/simpeg_drivers/utils/meshes.py
@@ -100,7 +100,7 @@ def auto_mesh_parameters(
             "w_cell_size": base_cell_size,
             "horizontal_padding": padding,
             "vertical_padding": padding if vertical_padding else 0,
-            "depth_core": padding,
+            "depth_core": padding if not vertical_padding else 0,
             "diagonal_balance": True,
             "Refinement A object": survey,
             "Refinement A levels": survey_refinement,

--- a/simpeg_drivers/utils/meshes.py
+++ b/simpeg_drivers/utils/meshes.py
@@ -50,7 +50,10 @@ def auto_pad(survey, factor=2) -> tuple[list[float], list[float]]:
 def use_vertical_padding(inversion_type):
     """Return true for all electrical and potential field methods."""
     out = True
-    if any(k in inversion_type for k in ["direct current", "induced polarization", "gravity", "magnetic"]):
+    if any(
+        k in inversion_type
+        for k in ["direct current", "induced polarization", "gravity", "magnetic"]
+    ):
         out = False
     return out
 

--- a/simpeg_drivers/utils/meshes.py
+++ b/simpeg_drivers/utils/meshes.py
@@ -36,15 +36,25 @@ def auto_pad(survey, factor=2) -> tuple[list[float], list[float]]:
     :param factor: Horizontal padding is the largest survey span (x or y)
         divided by the factor value, ex: factor=2 will pad the survey in
         all horizontal directions by half the largest survey extent.
-    :returns horizontal_padding: List of horizontal padding values.
-    :returns vertical_padding: List of vertical padding values
+    :returns padding: Estimated padding distance rounded to nearest 100.
     """
 
     lower = survey[:, :2].min(axis=0)
     upper = survey[:, :2].max(axis=0)
     padding = np.max(upper - lower) / factor
+    padding = round_nearest(padding, 100)
 
     return padding
+
+
+def use_vertical_padding(inversion_type):
+    """Return true for all electrical and potential field methods."""
+    out = False
+    if any(k in inversion_type for k in ["direct current", "induced polarization"]):
+        out = True
+    if inversion_type in ["gravity", "magnetic scalar", "magnetic vector"]:
+        out = False
+    return out
 
 
 def auto_mesh_parameters(
@@ -53,6 +63,7 @@ def auto_mesh_parameters(
     survey_refinement: list[int] | None = None,
     topography_refinement: list[int] | None = None,
     cell_size_factor: int = 2,
+    inversion_type: str | None = None,
 ) -> OctreeParams:
     """
     Return a mesh optimized for the provided data extents and spacing.
@@ -78,6 +89,7 @@ def auto_mesh_parameters(
         spacing = station_spacing(survey.locations) / cell_size_factor
         base_cell_size = round_nearest(spacing, 5)
         padding = auto_pad(survey.locations)
+        vertical_padding = use_vertical_padding(inversion_type)
 
         params_dict = {
             "geoh5": workspace,
@@ -86,8 +98,8 @@ def auto_mesh_parameters(
             "v_cell_size": base_cell_size,
             "w_cell_size": base_cell_size,
             "horizontal_padding": padding,
-            "vertical_padding": padding,
-            "depth_core": 500.0,
+            "vertical_padding": padding if vertical_padding else 0,
+            "depth_core": padding,
             "diagonal_balance": True,
             "Refinement A object": survey,
             "Refinement A levels": survey_refinement,

--- a/tests/utils_meshes_test.py
+++ b/tests/utils_meshes_test.py
@@ -67,7 +67,7 @@ def test_round_nearest():
 
 
 def test_auto_pad():
-    x = np.linspace(0, 1000, 101)
+    x = np.linspace(0, 975, 101)
     y = np.linspace(0, 500, 501)
     x_grid, y_grid = np.meshgrid(x, y)
     z = np.ones_like(x_grid)
@@ -84,9 +84,10 @@ def test_auto_mesh_parameters(tmp_path):
     survey = Points.create(ws, name="survey", vertices=locs)
     topo = Points.create(ws, name="topography", vertices=topo)
 
-    params = auto_mesh_parameters(survey, topo)
+    params = auto_mesh_parameters(survey, topo, inversion_type="gravity")
     mesh = OctreeDriver.octree_from_params(params)
 
     assert mesh.u_cell_size == 10
     assert mesh.v_cell_size == 10
     assert mesh.w_cell_size == 10
+    assert params.vertical_padding == 0


### PR DESCRIPTION
**GEOPY-1880 - Auto-meshing: Only use depth_code (no vertical pads) for potential fields and DC-IP inversions**
