### PR TITLE
GEOPY-2684: Transfer visual parameters Core volume settings from the input mesh to the inversion mesh (if present)

### DIFF
--- a/simpeg_drivers/components/meshes.py
+++ b/simpeg_drivers/components/meshes.py
@@ -12,15 +12,12 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING
 
 import numpy as np
 from discretize import TensorMesh, TreeMesh
 from geoh5py import Workspace
-from geoh5py.groups import UIJsonGroup
 from geoh5py.objects import DrapeModel, Grid2D, Octree, Points
 from grid_apps.octree_creation.driver import OctreeDriver
-from grid_apps.octree_creation.options import OctreeOptions
 from grid_apps.utils import octree_2_treemesh, treemesh_2_octree
 from scipy.sparse import csr_matrix, identity
 
@@ -30,9 +27,6 @@ from simpeg_drivers.utils.utils import drape_2_tensor
 
 
 logger = getLogger(__name__)
-if TYPE_CHECKING:
-    from simpeg_drivers.components.data import InversionData
-    from simpeg_drivers.components.topography import InversionTopography
 
 
 # TODO: Import this from newer octree-creation-app release
@@ -107,6 +101,8 @@ class InversionMesh:
             mesh_entity = self.params.mesh.copy(
                 parent=self.params.out_group, copy_children=False
             )
+            if self.params.mesh.visual_parameters is not None:
+                self.params.mesh.visual_parameters.copy(parent=mesh_entity)
 
         return mesh_entity
 

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -98,3 +98,35 @@ def test_target_chi(tmp_path: Path, caplog):
             assert driver.directives.update_irls_directive.chifact_start == 2.0
 
         assert "Starting chi factor is greater" in caplog.text
+
+
+def test_mesh_visual_parameters_copy(tmp_path: Path):
+    n_grid_points = 2
+    refinement = (2,)
+
+    opts = SyntheticsComponentsOptions(
+        method="gravity",
+        survey=SurveyOptions(n_stations=n_grid_points, n_lines=n_grid_points),
+        mesh=MeshOptions(refinement=refinement),
+        model=ModelOptions(anomaly=0.75),
+    )
+    with get_workspace(tmp_path / "inversion_test.ui.geoh5") as geoh5:
+        components = SyntheticsComponents(geoh5, options=opts)
+
+        gz = components.survey.add_data(
+            {"gz": {"values": np.ones(components.survey.n_vertices)}}
+        )
+        mesh = components.model.parent
+        mesh.add_default_visual_parameters()
+        mesh.visual_parameters.colour = [255, 0, 0]
+        params = GravityInversionOptions.build(
+            geoh5=geoh5,
+            mesh=mesh,
+            topography_object=components.topography,
+            data_object=gz.parent,
+            starting_model=1e-4,
+            gz_channel=gz,
+            gz_uncertainty=2e-3,
+        )
+        driver = GravityInversionDriver(params)
+        assert driver.inversion_mesh.entity.visual_parameters.colour == [255, 0, 0]

--- a/tests/run_tests/driver_mvi_test.py
+++ b/tests/run_tests/driver_mvi_test.py
@@ -141,7 +141,7 @@ def test_magnetic_vector_run(
                 inducing_field_declination=inducing_field[2],
                 data_object=tmi.parent,
                 starting_model=1e-4,
-                reference_model=0.0,
+                reference_model=0.1,
                 gradient_rotation=gradient_rotation,
                 s_norm=0.0,
                 x_norm=1.0,

--- a/tests/run_tests/driver_mvi_test.py
+++ b/tests/run_tests/driver_mvi_test.py
@@ -141,7 +141,7 @@ def test_magnetic_vector_run(
                 inducing_field_declination=inducing_field[2],
                 data_object=tmi.parent,
                 starting_model=1e-4,
-                reference_model=0.1,
+                reference_model=0.0,
                 gradient_rotation=gradient_rotation,
                 s_norm=0.0,
                 x_norm=1.0,


### PR DESCRIPTION
**GEOPY-2684 - Transfer visual parameters Core volume settings from the input mesh to the inversion mesh (if present)**
