### PR TITLE
GEOPY-2665: Accept 2D inversion mesh (DrapeModel) in `sensitivity_cutoff` application

### DIFF
--- a/simpeg_drivers-assets/uijson/sensitivity_cutoff.ui.json
+++ b/simpeg_drivers-assets/uijson/sensitivity_cutoff.ui.json
@@ -11,7 +11,8 @@
     "mesh": {
         "main": true,
         "meshType": [
-            "4ea87376-3ece-438b-bf12-3479733ded46"
+            "4ea87376-3ece-438b-bf12-3479733ded46",
+            "C94968EA-CF7D-11EB-B8BC-0242AC130003"
         ],
         "label": "Mesh",
         "value": ""

--- a/simpeg_drivers-assets/uijson/sensitivity_cutoff.ui.json
+++ b/simpeg_drivers-assets/uijson/sensitivity_cutoff.ui.json
@@ -11,8 +11,8 @@
     "mesh": {
         "main": true,
         "meshType": [
-            "4ea87376-3ece-438b-bf12-3479733ded46",
-            "C94968EA-CF7D-11EB-B8BC-0242AC130003"
+            "{4ea87376-3ece-438b-bf12-3479733ded46}",
+            "{c94968ea-cf7d-11eb-b8bc-0242ac130003}"
         ],
         "label": "Mesh",
         "value": ""

--- a/simpeg_drivers/depth_of_investigation/sensitivity_cutoff/options.py
+++ b/simpeg_drivers/depth_of_investigation/sensitivity_cutoff/options.py
@@ -13,7 +13,7 @@ from typing import ClassVar
 
 from geoapps_utils.base import Options
 from geoh5py.data import FloatData
-from geoh5py.objects import Octree
+from geoh5py.objects import DrapeModel, Octree
 from pydantic import field_validator
 
 from simpeg_drivers import assets_path
@@ -41,7 +41,7 @@ class SensitivityCutoffOptions(Options):
     run_command: str = "simpeg_drivers.depth_of_investigation.sensitivity_cutoff.driver"
 
     conda_environment: str = "simpeg_drivers"
-    mesh: Octree
+    mesh: Octree | DrapeModel
     sensitivity_model: FloatData
     sensitivity_cutoff: float = 0.1
     cutoff_method: str = "percentile"

--- a/simpeg_drivers/depth_of_investigation/sensitivity_cutoff/options.py
+++ b/simpeg_drivers/depth_of_investigation/sensitivity_cutoff/options.py
@@ -23,7 +23,7 @@ class SensitivityCutoffOptions(Options):
     """
     Sensitivity cutoff parameters for depth of investigation studies.
 
-    :param mesh: Octree mesh containing saved sensitivities.
+    :param mesh: Octree mesh or DrapeModel containing saved sensitivities.
     :param sensitivity_model: Saved row-sum-squared sensitivity data.
     :param sensitivity_cutoff: Sensitivity percentage below which the
         model's influence to the data is considered negligible.


### PR DESCRIPTION
**GEOPY-2665 - Accept 2D inversion mesh (DrapeModel) in `sensitivity_cutoff` application**
