### PR TITLE
GEOPY-2852: Make simpeg group names in plate-simulation more clear in the ui.jsons

### DIFF
--- a/simpeg_drivers-assets/uijson/plate_simulation.ui.json
+++ b/simpeg_drivers-assets/uijson/plate_simulation.ui.json
@@ -9,7 +9,7 @@
     "monitoring_directory": "",
     "simulation": {
         "main": true,
-        "label": "SimPEG group",
+        "label": "Forward group",
         "groupType": [
             "{55ed3daf-c192-4d4b-a439-60fa987fe2b8}",
             "{BB50AC61-A657-4926-9C82-067658E246A0}"
@@ -126,11 +126,6 @@
         "min": 0.0,
         "tooltip": "Depth below topography to the plate centre (positive down)."
     },
-    "generate_sweep": {
-        "label": "Generate sweep file",
-        "main": true,
-        "value": false
-    },
     "u_cell_size": {
         "min": 0.0,
         "group": "Mesh",
@@ -196,7 +191,7 @@
         "enabled": true
     },
     "out_group": {
-        "label": "Simulation group",
+        "label": "SimPEG group",
         "value": "",
         "groupType": "{55ed3daf-c192-4d4b-a439-60fa987fe2b8}",
         "visible": true,


### PR DESCRIPTION
**GEOPY-2852 - Make simpeg group names in plate-simulation more clear in the ui.jsons**
