### PR TITLE
GEOPY-2862: Inversion crash on tile mesh creation transferring data

### DIFF
--- a/simpeg_drivers/components/meshes.py
+++ b/simpeg_drivers/components/meshes.py
@@ -251,7 +251,7 @@ class InversionMesh:
         indices = treemesh.get_containing_cells(mesh.centroids)
         ind = np.argsort(indices)
         for child in mesh.children:
-            if child.values is None or isinstance(child.values, np.ndarray):
+            if child.values is None or not isinstance(child.values, np.ndarray):
                 continue
             child.values = child.values[ind]
 

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -129,4 +129,5 @@ def test_mesh_visual_parameters_copy(tmp_path: Path):
             gz_uncertainty=2e-3,
         )
         driver = GravityInversionDriver(params)
+        assert driver.inversion_mesh.ensure_cell_convention(mesh) is not None
         assert driver.inversion_mesh.entity.visual_parameters.colour == [255, 0, 0]


### PR DESCRIPTION
**GEOPY-2862 - Inversion crash on tile mesh creation transferring data**
