### PR TITLE
GEOPY-2879: Allow rotated receivers for ground EM survey

### DIFF
--- a/simpeg_drivers/components/factories/receiver_factory.py
+++ b/simpeg_drivers/components/factories/receiver_factory.py
@@ -24,7 +24,10 @@ if TYPE_CHECKING:
 
 import numpy as np
 from geoapps_utils.utils.transformations import x_rotation_matrix, z_rotation_matrix
-from geoh5py.objects.surveys.electromagnetics.base import AirborneEMSurvey
+from geoh5py.objects.surveys.electromagnetics.base import (
+    AirborneEMSurvey,
+    LargeLoopGroundEMSurvey,
+)
 
 from simpeg_drivers.components.factories.simpeg_factory import SimPEGFactory
 from simpeg_drivers.utils.regularization import direction_and_dip, get_cell_normals
@@ -189,7 +192,9 @@ class ReceiversFactory(SimPEGFactory):
 
         # Overload orientation if provided
         if (
-            isinstance(self.params.data_object, AirborneEMSurvey)
+            isinstance(
+                self.params.data_object, AirborneEMSurvey | LargeLoopGroundEMSurvey
+            )
             and local_indices is not None
         ):
             kwargs["orientation"] = self.orientations[kwargs["orientation"]][

--- a/simpeg_drivers/components/factories/receiver_factory.py
+++ b/simpeg_drivers/components/factories/receiver_factory.py
@@ -197,10 +197,13 @@ class ReceiversFactory(SimPEGFactory):
             )
             and local_indices is not None
         ):
-            kwargs["orientation"] = self.orientations[kwargs["orientation"]][
-                local_indices, :
-            ]
+            orientations = self.orientations[kwargs["orientation"]][local_indices, :]
 
+            # TODO: GEOPY-2880: Generalize simpeg to allow 2D array of orientations
+            if orientations.ndim == 2:
+                orientations = np.mean(orientations, axis=0)
+
+            kwargs["orientation"] = orientations
         return kwargs
 
     def _dcip_arguments(self, locations=None, local_indices=None):


### PR DESCRIPTION
**GEOPY-2879 - Allow rotated receivers for ground EM survey**
