### PR TITLE
DEVOPS-1095: Applying the same skipped tests that are skipped in the feedstocks recipe

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -72,7 +72,7 @@ tests:
       pip_check: true
 
   - script:
-      - pytest --ignore=tests/version_test.py
+      - pytest --ignore=tests/version_test.py --ignore=tests/run_tests --ignore=tests/plate_simulation
     requirements:
       run:
         - pytest


### PR DESCRIPTION
**DEVOPS-1095 - have some tests for simpeg-drivers part of the conda-forge recipe**
