### PR TITLE
DEVOPS-1077: Fix concurrency group to use github.ref instead of github.head_ref

### DIFF
--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -20,7 +20,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -20,7 +20,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
**DEVOPS-1077 - auto-cancel workflow upon new push to a branch**
Change the workflow concurrency group key from `github.head_ref || github.run_id` to `github.ref`.

Part of DEVOPS-1077: change-group-concurrency

Authored using a powershell script with the help of CO-Pilot.